### PR TITLE
Fixed ExifTool download and resulting build error

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -10,6 +10,7 @@ ENV PATH="$PYTHONUSERBASE/bin:$PATH"
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         bc \
+        jq \
         ffmpeg \
         ghostscript \
         imagemagick \
@@ -18,7 +19,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # hadolint ignore=DL3003
-RUN EXIFTOOL_VERSION="$(wget -qO- https://exiftool.org/ver.txt)" \
+RUN EXIFTOOL_VERSION="$(wget -qO- https://api.github.com/repos/exiftool/exiftool/tags | jq -r '.[0].name')" \
     && wget --progress=dot:giga https://netix.dl.sourceforge.net/project/exiftool/Image-ExifTool-"${EXIFTOOL_VERSION}".tar.gz \
     && tar xvf Image-ExifTool-"${EXIFTOOL_VERSION}".tar.gz \
     && cd Image-ExifTool-"${EXIFTOOL_VERSION}"/ \


### PR DESCRIPTION
The site referenced in the Dockerfile (`https://exiftool.org/`) seems to have problems, so the Exif download and build fails.

I couldn't find any info about SourceForge offering an API for the version so I used the GitHub mirror to get that information.

The Exif download still comes from SF since I don't know the project structure well enough to just switch over to a different hoster.